### PR TITLE
Support Svelte5 peerDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "node": ">=10.0.0"
             },
             "peerDependencies": {
-                "svelte": "4.x"
+                "svelte": "^4.0.0 || ^5.0.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,6 @@
         "svelte": "^3.0.0"
     },
     "peerDependencies": {
-        "svelte": "4.x"
+        "svelte": "^4.0.0 || ^5.0.0"
     }
 }


### PR DESCRIPTION
The api for stores didn't change with Svelte 5, so this updates the package to be current and more compatible with the peerDependencies.

Tested the code on a Svelte5 project and didn't run into issues with it.